### PR TITLE
Functionality to exclude objects globally by types

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.2.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add functionality to exclude portal_types over the plone.app.registry.
+  [elioschmutz]
 
 
 1.2.7 (2013-04-17)

--- a/ftw/dashboard/portlets/recentlymodified/profiles/default/metadata.xml
+++ b/ftw/dashboard/portlets/recentlymodified/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1270</version>
+  <version>1280</version>
   <dependencies>
     <dependency>profile-collective.js.jqsmartTruncation:default</dependency>
   </dependencies>

--- a/ftw/dashboard/portlets/recentlymodified/profiles/default/registry.xml
+++ b/ftw/dashboard/portlets/recentlymodified/profiles/default/registry.xml
@@ -1,0 +1,12 @@
+<registry>
+    <record name="ftw.dashboard.portlets.recentlymodified.types_to_exclude">
+        <field type="plone.registry.field.List">
+            <description>Add portaltypes you want to exclude from the recently modified portlet</description>
+            <title>Types to exclude</title>
+            <value_type type="plone.registry.field.TextLine" />
+        </field>
+        <value>
+            <element>Image</element>
+        </value>
+    </record>
+</registry>

--- a/ftw/dashboard/portlets/recentlymodified/testing.py
+++ b/ftw/dashboard/portlets/recentlymodified/testing.py
@@ -1,3 +1,4 @@
+from ftw.builder.testing import BUILDER_LAYER
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
@@ -8,7 +9,7 @@ from zope.configuration import xmlconfig
 
 class FtwRecentlymodifiedLayer(PloneSandboxLayer):
 
-    defaultBases = (PLONE_FIXTURE, )
+    defaultBases = (PLONE_FIXTURE, BUILDER_LAYER)
 
     def setUpZope(self, app, configurationContext):
         # Load ZCML
@@ -16,7 +17,7 @@ class FtwRecentlymodifiedLayer(PloneSandboxLayer):
 
         xmlconfig.file(
             'configure.zcml', ftw.dashboard.portlets.recentlymodified,
-                context=configurationContext)
+            context=configurationContext)
 
     def setUpPloneSite(self, portal):
         # Install into Plone site using portal_setup
@@ -24,9 +25,6 @@ class FtwRecentlymodifiedLayer(PloneSandboxLayer):
 
         setRoles(portal, TEST_USER_ID, ['Manager'])
         login(portal, TEST_USER_NAME)
-        # Create one folder with one item
-        portal.invokeFactory('Folder', 'folder1', title='Folder1')
-        portal.folder1.invokeFactory('Document', 'doc', title='Document')
 
 
 FTW_RECENTLYMODIFIED_FIXTURE = FtwRecentlymodifiedLayer()

--- a/ftw/dashboard/portlets/recentlymodified/upgrades/configure.zcml
+++ b/ftw/dashboard/portlets/recentlymodified/upgrades/configure.zcml
@@ -22,4 +22,22 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <genericsetup:upgradeStep
+        title="Add plone.app.registry record.."
+        description=""
+        source="1270"
+        destination="1280"
+        handler=".to1280.AddRegistryRecord"
+        profile="ftw.dashboard.portlets.recentlymodified:default"
+        />
+
+    <genericsetup:registerProfile
+        name="1280"
+        title="ftw.dashboard.portlets.recentlymodified.upgrades.1280"
+        description=""
+        directory="profiles/1280"
+        for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
 </configure>

--- a/ftw/dashboard/portlets/recentlymodified/upgrades/profiles/1280/registry.xml
+++ b/ftw/dashboard/portlets/recentlymodified/upgrades/profiles/1280/registry.xml
@@ -1,0 +1,12 @@
+<registry>
+    <record name="ftw.dashboard.portlets.recentlymodified.types_to_exclude">
+        <field type="plone.registry.field.List">
+            <description>Add portaltypes you want to exclude from the recently modified portlet</description>
+            <title>Types to exclude</title>
+            <value_type type="plone.registry.field.TextLine" />
+        </field>
+        <value>
+            <element>Image</element>
+        </value>
+    </record>
+</registry>

--- a/ftw/dashboard/portlets/recentlymodified/upgrades/to1280.py
+++ b/ftw/dashboard/portlets/recentlymodified/upgrades/to1280.py
@@ -1,0 +1,8 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddRegistryRecord(UpgradeStep):
+
+    def __call__(self):
+        self.setup_install_profile(
+            'profile-ftw.dashboard.portlets.recentlymodified.upgrades:1280')

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,8 @@ maintainer = 'Philipp Gross'
 tests_require = ['zope.testing',
                  'plone.app.testing',
                  'plone.mocktestcase',
+                 'ftw.builder',
+                 'ftw.testing [splinter]',
                  ]
 
 setup(name='ftw.dashboard.portlets.recentlymodified',


### PR DESCRIPTION
@jone @buchi Add functionality to exclude portal_types over the plone.app.registry.
