### PR TITLE
Remove dependency on ftw.testing[splinter]

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.3.4 (unreleased)
 ------------------
 
+- Remove dependency on ftw.testing[splinter] (has been dropped in ftw.testing). [lgraf]
+
 - Drop Plone 4.1 support [jone]
 
 

--- a/ftw/dashboard/portlets/recentlymodified/testing.py
+++ b/ftw/dashboard/portlets/recentlymodified/testing.py
@@ -1,15 +1,15 @@
 from ftw.builder.session import BuilderSession
 from ftw.builder.testing import BUILDER_LAYER, set_builder_session_factory
-import ftw.dashboard.portlets.recentlymodified.tests.builders
-from ftw.testing import FunctionalSplinterTesting
+from plone.app.testing import applyProfile
+from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
-from plone.app.testing import applyProfile
 from plone.app.testing import setRoles, TEST_USER_ID, TEST_USER_NAME, login
 from zope.configuration import xmlconfig
 from zope.event import notify
 from zope.traversing.interfaces import BeforeTraverseEvent
+import ftw.dashboard.portlets.recentlymodified.tests.builders  # noqa
 
 
 def functional_session_factory():
@@ -38,7 +38,7 @@ class FtwRecentlymodifiedLayer(PloneSandboxLayer):
         login(portal, TEST_USER_NAME)
 
 
-class FunctionalBrowserlayerTesting(FunctionalSplinterTesting):
+class FunctionalBrowserlayerTesting(FunctionalTesting):
     """Support browserlayer"""
 
     def setUpEnvironment(self, portal):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ maintainer = 'Philipp Gross'
 tests_require = [
     'ftw.builder',
     'ftw.testbrowser',
-    'ftw.testing [splinter]',
+    'ftw.testing',
     'plone.app.testing',
     'plone.mocktestcase',
     'zope.testing',


### PR DESCRIPTION
This removes the dependency on the `ftw.testing[splinter]` extra, which has been [dropped from 
`ftw.testing`](https://github.com/4teamwork/ftw.testing/commit/6eadb49bed08a0b40113d65abf8b302935cb1007).